### PR TITLE
Add funjumpsmap to haste map list & rm df_verihard

### DIFF
--- a/race.py
+++ b/race.py
@@ -15,7 +15,7 @@ import requests
 PARAMS = ({}, {"weapons": "false"}, {"factory": "classic"}, {"factory": "classic", "weapons": "false"})
 OLDTOP_URL = "https://cdn.rawgit.com/QLRace/oldtop/master/oldtop/"
 
-HASTE = ("df_handbreaker4", "handbreaker4_long", "handbreaker", "df_piyofunjumps", "df_verihard", "df_luna",
+HASTE = ("df_handbreaker4", "handbreaker4_long", "handbreaker", "df_piyofunjumps", "funjumpsmap", "df_luna",
          "df_nodown", "df_etleague", "df_extremepkr", "labyrinth", "airmaxjumps", "sarcasmjump", "criclejump",
          "cursed_temple", "skacharohuth", "randommap", "just_jump_3", "criclejump", "eatme")
 NO_WEAPONS = ("df_bardoklick", "df_bardoklickrevamped", "df_lickagain", "df_lickape", "df_lickcells",


### PR DESCRIPTION
Since I updated the workshop & added 2 maps (funjumpsmap & insane1), and !goto doesn't make sense in df_verihard or insane1